### PR TITLE
Upgrade to Bocadillo 0.13.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     scripts=[],
     entry_points={"console_scripts": ["termpair=termpair.main:main"]},
     zip_safe=False,
-    install_requires=["bocadillo>=0.13"],
+    install_requires=["bocadillo>=0.13.1"],
     extras_require={"dev": ["mkdocs", "mkdocs-material", "mypy", "black"]},
     test_suite="tests.test_project",
     python_requires=">=3.6",

--- a/termpair/server.py
+++ b/termpair/server.py
@@ -60,51 +60,50 @@ async def index(req, res):
             command=terminal.command,
             broadcast_start_time_iso=terminal.broadcast_start_time_iso,
         )
-        res.html = await templates.render("index.html", initial_data=initial_data)
-    else:
-        initial_data = dict(
-            cols=50, rows=15, allow_browser_control=False
+        res.html = await templates.render(
+            "index.html", initial_data=initial_data
         )
-        res.html = await templates.render("index.html", initial_data=initial_data)
+    else:
+        initial_data = dict(cols=50, rows=15, allow_browser_control=False)
+        res.html = await templates.render(
+            "index.html", initial_data=initial_data
+        )
 
 
 @app.websocket_route("/connect_browser_to_terminal")
 async def connect_browser_to_terminal(ws):
+    web_clients = set()
     try:
-        web_clients = set()
-        async with ws:
-            terminal_id = ws.query_params.get("id", None)
-            terminal = terminals.get(terminal_id)
-            if not terminal:
-                raise ValueError("no terminal with id", terminal_id)
+        terminal_id = ws.query_params.get("id", None)
+        terminal = terminals.get(terminal_id)
+        if not terminal:
+            raise ValueError("no terminal with id", terminal_id)
 
-            web_clients = terminal.web_clients
-            web_clients.add(ws)
+        web_clients = terminal.web_clients
+        web_clients.add(ws)
 
-            for web_client in terminal.web_clients:
-                try:
-                    await web_client.send_json(
-                        {"event": "num_clients", "payload": len(web_clients)}
-                    )
-                except:
-                    pass
+        for web_client in terminal.web_clients:
+            try:
+                await web_client.send_json(
+                    {"event": "num_clients", "payload": len(web_clients)}
+                )
+            except:
+                pass
 
-            while True:
-                browser_input = await ws.receive()
-                if terminal.allow_browser_control:
-                    await terminal.ws.send(
-                        json.dumps({"event": "command", "payload": browser_input})
-                    )
-                else:
-                    asyncio.sleep(100)
+        while True:
+            browser_input = await ws.receive()
+            if terminal.allow_browser_control:
+                await terminal.ws.send(
+                    json.dumps({"event": "command", "payload": browser_input})
+                )
+            else:
+                asyncio.sleep(100)
 
     except starlette.websockets.WebSocketDisconnect:
         for web_client in web_clients:
             await web_client.send_json(
                 {"event": "num_clients", "payload": len(web_clients) - 1}
             )
-    except Exception:
-        print(traceback.format_exc())
 
 
 async def _forward_terminal_data_to_web_clients(terminal: Terminal):
@@ -159,31 +158,30 @@ def _gen_terminal_id(ws: WebSocket) -> TerminalId:
 @app.websocket_route("/connect_to_terminal")
 async def connect_to_terminal(ws):
     try:
-        async with ws:
-            terminal_id = _gen_terminal_id(ws)
-            data = await ws.receive_json()
-            terminal = Terminal(
-                ws=ws,
-                web_clients=set(),
-                rows=data["rows"],
-                cols=data["cols"],
-                allow_browser_control=data["allow_browser_control"],
-                command=data["command"],
-                broadcast_start_time_iso=data["broadcast_start_time_iso"],
-            )
-            terminals[terminal_id] = terminal
+        terminal_id = _gen_terminal_id(ws)
+        data = await ws.receive_json()
+        terminal = Terminal(
+            ws=ws,
+            web_clients=set(),
+            rows=data["rows"],
+            cols=data["cols"],
+            allow_browser_control=data["allow_browser_control"],
+            command=data["command"],
+            broadcast_start_time_iso=data["broadcast_start_time_iso"],
+        )
+        terminals[terminal_id] = terminal
 
-            await ws.send(
-                json.dumps({"event": "start_broadcast", "payload": terminal_id})
-            )
+        await ws.send(
+            json.dumps({"event": "start_broadcast", "payload": terminal_id})
+        )
 
-            t1 = asyncio.ensure_future(_forward_terminal_data_to_web_clients(terminal))
-            done, pending = await (
-                asyncio.wait([t1], return_when=asyncio.FIRST_COMPLETED)
-            )
-            for task in pending:
-                task.cancel()
-    except Exception:
-        print(traceback.format_exc())
+        t1 = asyncio.ensure_future(
+            _forward_terminal_data_to_web_clients(terminal)
+        )
+        done, pending = await (
+            asyncio.wait([t1], return_when=asyncio.FIRST_COMPLETED)
+        )
+        for task in pending:
+            task.cancel()
     finally:
         terminals.pop(terminal_id, None)


### PR DESCRIPTION
0.13.1 adds WebSocket auto-accept, so I updated the code to use that instead of `async with ws:` blocks. It also shows the exception traceback by default now. :+1: