### PR TITLE
Ensure error message is printed to browser's terminal if site is not served in a secure context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.0.3
+* Ensure error message is printed to browser's terminal if site is not served in a secure context (#39)
+
 ## 0.1.0.2
 * Change default sharing port to None due to difficulties sharing to port 80/reverse proxies
 * Print port in web UI's sharing command

--- a/termpair/main.py
+++ b/termpair/main.py
@@ -61,7 +61,7 @@ def main():
         description=(
             "Run termpair server to route messages between unix terminals and browsers. "
             "Run this before connecting any clients. "
-            "It is recommended to encrypt communication by using SSL/TLS. "
+            "TermPair only works in secure contexts; SSL/TLS is generally required. "
             "To generate an SSL certificate and private key, run "
             "`openssl req -newkey rsa:2048 -nodes -keyout host.key -x509 -days 365 -out host.crt`. "
             "To skip questions and use defaults, add the `-batch` flag. "


### PR DESCRIPTION
The logic to display the error message had a bug. This PR fixes the bug and prints a red message in the terminal if the browser is not running in a secure context where `window.crypto` is unavailable.See https://developer.mozilla.org/en-US/docs/Web/API/Window/crypto.

fixes #39 