### PR TITLE
make default client port 8000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.1.0.3
+## 0.1.1.0
 * Ensure error message is printed to browser's terminal if site is not served in a secure context (#39)
+* Make default port terminal client connection port 8000 to match default server port (#38)
 
 ## 0.1.0.2
 * Change default sharing port to None due to difficulties sharing to port 80/reverse proxies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.1.0
 * Ensure error message is printed to browser's terminal if site is not served in a secure context (#39)
-* Make default port terminal client connection port 8000 to match default server port (#38)
+* Make default TermPair terminal client port 8000 to match default server port (#38)
 
 ## 0.1.0.2
 * Change default sharing port to None due to difficulties sharing to port 80/reverse proxies

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ TermPair lets developers securely share and control terminals in real time.
 Start the TermPair server with `termpair serve`, or use the one already running at [https://grassfedcode.com/termpair](https://grassfedcode.com/termpair).
 
 ```
-> termpair serve
+> termpair serve --port 8000
 INFO:     Started server process [25289]
 INFO:     Waiting for application startup.
 INFO:     Application startup complete.

--- a/termpair/frontend_src/src/App.js
+++ b/termpair/frontend_src/src/App.js
@@ -203,8 +203,8 @@ function writeInstructions(xterm) {
   const host = `${window.location.protocol}//${window.location.hostname}${window.location.pathname}`;
   xterm.writeln("");
   xterm.writeln(
-    `    pipx run termpair share --host "${host}" ${
-      window.location.port ? "--port " + window.location.port : ""
+    `    pipx run termpair share --host "${host}" --port ${
+      window.location.port ? window.location.port : "80"
     }`
   );
   xterm.writeln("");

--- a/termpair/main.py
+++ b/termpair/main.py
@@ -37,7 +37,7 @@ def main():
         ),
     )
     share_parser.add_argument(
-        "--port", "-p", default=None, help="port server is running on"
+        "--port", "-p", default=8000, help="port server is running on"
     )
     share_parser.add_argument(
         "--host", default="http://localhost", help="host server is running on"


### PR DESCRIPTION
The default port when sharing a terminal is currently `None` which defaults to port 80. The default server port is 8000. Make them match for a better UX.

fixes #38