### PR TITLE
always display port in connection instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.1.0
 * Ensure error message is printed to browser's terminal if site is not served in a secure context (#39)
 * Make default TermPair terminal client port 8000 to match default server port (#38)
+* Always display port to connect to in browser's connection instructions
 
 ## 0.1.0.2
 * Change default sharing port to None due to difficulties sharing to port 80/reverse proxies

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ The server multicasts terminal output to all browsers that connect to the sessio
 
 TermPair uses 128 bit end-to-end encryption for all terminal input and output.
 
-### How it Works
+The browser must be running in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). This typically means running on localhost, or with secure http traffic (https).
+
+## How it Works
 
 <div style="text-align: center">
     <a href="https://github.com/cs01/termpair/raw/master/docs/termpair_architecture.png">

--- a/termpair/frontend_src/src/App.js
+++ b/termpair/frontend_src/src/App.js
@@ -202,11 +202,15 @@ function writeInstructions(xterm) {
   xterm.writeln("To broadcast a terminal, run");
   const host = `${window.location.protocol}//${window.location.hostname}${window.location.pathname}`;
   xterm.writeln("");
-  xterm.writeln(
-    `    pipx run termpair share --host "${host}" --port ${
-      window.location.port ? window.location.port : "80"
-    }`
-  );
+  let port = window.location.port;
+  if (!window.location.port) {
+    if (window.location.protocol === "https:") {
+      port = 443;
+    } else {
+      port = 80;
+    }
+  }
+  xterm.writeln(`    pipx run termpair share --host "${host}" --port ${port}`);
   xterm.writeln("");
   xterm.writeln("Then open or share the url printed to the terminal.");
   xterm.writeln("To install pipx, see https://pipxproject.github.io/pipx/");

--- a/termpair/main.py
+++ b/termpair/main.py
@@ -9,7 +9,7 @@ from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware  # type: 
 import uvicorn  # type: ignore
 from . import share, server
 
-__version__ = "0.1.0.2"
+__version__ = "0.1.1.0"
 
 
 def main():


### PR DESCRIPTION
Previously it was assumed if the port was not defined in `window.location` that it was running on port 80. However, if the protocol is `https` it is running on port 443, not port 80.