### PR TITLE
fix middleware name in new FastAPI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1.1
+* Fix server bug when using SSL certs (#44)
+
 ## 0.1.1.0
 * Ensure error message is printed to browser's terminal if site is not served in a secure context (#39)
 * Make default TermPair terminal client port 8000 to match default server port (#38)

--- a/termpair/main.py
+++ b/termpair/main.py
@@ -9,7 +9,7 @@ from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware  # type: 
 import uvicorn  # type: ignore
 from . import share, server
 
-__version__ = "0.1.1.0"
+__version__ = "0.1.1.1"
 
 
 def main():
@@ -112,7 +112,7 @@ def main():
 
     elif args.command == "serve":
         if args.certfile or args.keyfile:
-            server.app.add_asgi_middleware(HTTPSRedirectMiddleware)
+            server.app.add_middleware(HTTPSRedirectMiddleware)
 
         uvicorn.run(
             server.app,


### PR DESCRIPTION
Dependencies were updated, and one of the method names changed. This PR updates the name to match the API in the newer version.

fixes #44