### PR TITLE
print better error message if TermPair server is not running

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- add an 'x' in the brackets below -->
-* [ ] I have added an entry to `docs/changelog.md`
+* [] I have added an entry to `CHANGELOG.md`
 
 ## Summary of changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.1.2.0
 * Add ability to copy+paste using keystrokes
+* Improve error messages, in particular if there is no server running
 
 ## 0.1.1.1
 * Fix server bug when using SSL certs (#44)

--- a/termpair/share.py
+++ b/termpair/share.py
@@ -226,28 +226,21 @@ async def broadcast_terminal(
 
     ws_url = url.replace("http", "ws")
 
-    try:
-        ws_endpoint = urljoin(ws_url, "connect_to_terminal")
-        async with websockets.connect(ws_endpoint, ssl=ssl_context) as ws:
-            secret_key = encryption.gen_key()
-            ws_id = await _initialize_broadcast(
-                cmd, url, ws, stdin_fd, pty_fd, allow_browser_control, secret_key
-            )
-            with utils.make_raw(stdin_fd):
-                await _do_broadcast(
-                    pty_fd,
-                    stdin_fd,
-                    stdout_fd,
-                    ws,
-                    _get_share_url(url, ws_id, secret_key),
-                    open_browser,
-                    allow_browser_control,
-                    secret_key,
-                )
-            print(f"You are no longer broadcasting session id {session_id}")
-    except websockets.exceptions.InvalidStatusCode as e:
-        print(
-            f"Failed to connect to {ws_endpoint}. "
-            "Check the url and port, and ensure the server is running."
+    ws_endpoint = urljoin(ws_url, "connect_to_terminal")
+    async with websockets.connect(ws_endpoint, ssl=ssl_context) as ws:
+        secret_key = encryption.gen_key()
+        ws_id = await _initialize_broadcast(
+            cmd, url, ws, stdin_fd, pty_fd, allow_browser_control, secret_key
         )
-        print(str(e))
+        with utils.make_raw(stdin_fd):
+            await _do_broadcast(
+                pty_fd,
+                stdin_fd,
+                stdout_fd,
+                ws,
+                _get_share_url(url, ws_id, secret_key),
+                open_browser,
+                allow_browser_control,
+                secret_key,
+            )
+        print(f"You are no longer broadcasting session id {session_id}")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Make error message more clear when server isn't running.

Before
```
Traceback (most recent call last):
  File "/home/csmith/git/termpair/.nox/broadcast/bin/termpair", line 33, in <module>
    sys.exit(load_entry_point('termpair', 'console_scripts', 'termpair')())
  File "/home/csmith/git/termpair/termpair/main.py", line 109, in main
    asyncio.get_event_loop().run_until_complete(
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/csmith/git/termpair/termpair/share.py", line 231, in broadcast_terminal
    async with websockets.connect(ws_endpoint, ssl=ssl_context) as ws:
  File "/home/csmith/git/termpair/.nox/broadcast/lib/python3.8/site-packages/websockets/legacy/client.py", line 604, in __aenter__
    return await self
  File "/home/csmith/git/termpair/.nox/broadcast/lib/python3.8/site-packages/websockets/legacy/client.py", line 622, in __await_impl__
    transport, protocol = await self._create_connection()
  File "/usr/lib/python3.8/asyncio/base_events.py", line 1025, in create_connection
    raise exceptions[0]
  File "/usr/lib/python3.8/asyncio/base_events.py", line 1010, in create_connection
    sock = await self._connect_sock(
  File "/usr/lib/python3.8/asyncio/base_events.py", line 924, in _connect_sock
    await self.sock_connect(sock, address)
  File "/usr/lib/python3.8/asyncio/selector_events.py", line 496, in sock_connect
    return await fut
  File "/usr/lib/python3.8/asyncio/selector_events.py", line 528, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 8000)
```

After
```
Connection was refused. Is the TermPair server running on the host and port specified?
[Errno 111] Connect call failed ('127.0.0.1', 8000)
```

I also added a message to report bugs if a different error is thrown with a little prefix to the stacktrace:
```
TermPair encountered an error. If you think this is a bug, it can be reported at https://github.com/cs01/termpair/issues

Traceback (most recent call last):
  File "/home/csmith/git/termpair/termpair/main.py", line 140, in main
    f
NameError: name 'f' is not defined
```

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
> nox -s broadcast 
nox > Running session broadcast
nox > Re-using existing virtual environment at .nox/broadcast.
Note: Frontend must be built for this to work
nox > python -m pip install -e .
nox > termpair share
Connection was refused. Is the TermPair server running on the host and port specified?
[Errno 111] Connect call failed ('127.0.0.1', 8000)
```

fixes #37 
