### PR TITLE
improve state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add a status bar to the bottom of the page
 * Show terminal dimensions in bottom status bar
 * Add toasts to notify user of various events
+* Fix bug where connected browsers do not have their websocket connection closed when terminal closes, which makes it look like the terminal is still connected when it is not.
 * Improve error messages, in particular if there is no server running
 * Fixed bug where websocket connection is briefly accepted regardless of whether a valid terminal id is provided to `/terminal/{terminal_id}`. Instead of returning a JSON object with the TermPair version, a 404 error is now returned.
 * [dev] migrate codebase to typescript


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `CHANGELOG.md`

## Summary of changes
* Make termpair icon a link to the page hosting termpair
* Add new terminal/website states and ensure they are all handled. This leads to better error messages, including around insecure contexts
* Print errors in red
* Rename some variables on the server
* Fix bug where connected browsers aren't notified if terminal closes its websocket connection 
## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
yarn build
nox -s server
# in new terminal
nox -s broadcast
```
