### PR TITLE
show youtube video on landing page instead of gif

### DIFF
--- a/termpair/frontend_src/src/LandingPageContent.tsx
+++ b/termpair/frontend_src/src/LandingPageContent.tsx
@@ -213,10 +213,15 @@ export function LandingPageContent(props: {
     <div className="py-2">
       <div className="text-xl  py-2">TermPair Demo</div>
       <div>
-        <img
-          alt="Screencast of TermPair"
-          src="https://raw.githubusercontent.com/cs01/termpair/master/termpair_browser.gif"
-        />
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/HF0UX4smrKk"
+          title="YouTube video player"
+          frameBorder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        ></iframe>
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
embed youtube video to save bandwidth, in case of a slow connection
