### PR TITLE
add salt to all messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ In this version, TermPair clients from previous versions cannot connect to this 
 * [bugfix] Terminal dimensions in browser match upon initial connection, instead of after resizing
 * Allow static site to route terminal traffic through other server. If static site is detected, user can enter the terminal id and server url in the browser UI.
 * Allow Terminal ID and initial encryption key to be entered on landing page
+* Add additional random string to each encrypted message
 * Display version in webpage
 * Add troubleshooting instructions to webpage
 

--- a/termpair/frontend_src/src/encryption.tsx
+++ b/termpair/frontend_src/src/encryption.tsx
@@ -4,7 +4,8 @@
 import { defaultBootstrapb64Key } from "./constants";
 
 const IV_LENGTH = 12;
-
+type Base64String = string;
+type EncryptedBase64String = string;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ab2str(buf: ArrayBuffer): string {
   // @ts-ignore
@@ -84,7 +85,7 @@ export async function aesEncrypt(
   browserSecretAESKey: CryptoKey,
   utf8Payload: string,
   ivCount: number
-) {
+): Promise<EncryptedBase64String> {
   // The same iv must never be reused with a given key
   const iv = ivFromInteger(ivCount);
   const encryptedArrayBuffer = await window.crypto.subtle.encrypt(
@@ -116,7 +117,7 @@ function _combineBuffers(
   return tmp.buffer;
 }
 
-function _arrayBufferToBase64(buffer: ArrayBuffer) {
+function _arrayBufferToBase64(buffer: ArrayBuffer): Base64String {
   const bytes = new Uint8Array(buffer);
   let binary = "";
   const len = bytes.byteLength;

--- a/termpair/frontend_src/src/events.tsx
+++ b/termpair/frontend_src/src/events.tsx
@@ -1,5 +1,9 @@
 import { aesEncrypt } from "./encryption";
 
+function getSalt(): string {
+  return window.crypto.getRandomValues(new Uint8Array(12)).toString();
+}
+
 export function requestTerminalDimensions() {
   return JSON.stringify({ event: "request_terminal_dimensions" });
 }
@@ -17,7 +21,11 @@ export async function sendCommandToTerminal(
 ) {
   return JSON.stringify({
     event: "command",
-    payload: await aesEncrypt(secretEncryptionKey, data, messageCount),
+    payload: await aesEncrypt(
+      secretEncryptionKey,
+      JSON.stringify({ data, salt: getSalt() }),
+      messageCount
+    ),
   });
 }
 

--- a/termpair/frontend_src/src/websocketMessageHandler.tsx
+++ b/termpair/frontend_src/src/websocketMessageHandler.tsx
@@ -25,11 +25,13 @@ export const handlers = {
       );
       return;
     }
-    const decryptedPayload = await aesDecrypt(
+    const decryptedJson = await aesDecrypt(
       aesKeys.current.unix,
       Buffer.from(data.payload, "base64")
     );
-    xterm.write(decryptedPayload);
+    const decryptedPayload = JSON.parse(decryptedJson.toString());
+    const pty_output = Buffer.from(decryptedPayload.pty_output, "base64");
+    xterm.write(pty_output);
   },
   resize: function (
     data: any,


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `CHANGELOG.md`

## Summary of changes
* Add additional random string to each encrypted message (bullet 2 of #36)
* This changes the message format from just sending the output as the payload to sending a json string with the output and a 12 byte salt.
* Also updated the readme
