### PR TITLE
rename `--no-browser-control` to `--read-only`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ In this version, TermPair clients from previous versions cannot connect to this 
 * Add additional random string to each encrypted message
 * Display version in webpage
 * Add troubleshooting instructions to webpage
-
+* Rename `--no-browser-control` argument of `termpair share` to `--read-only`
 
 ## 0.2.0.0
 * Add ability to copy+paste using keystrokes (copy with ctrl+shift+c or ctrl+shift+x, and paste with ctrl+shift+v)

--- a/README.md
+++ b/README.md
@@ -277,21 +277,20 @@ optional arguments:
 To share a terminal using the TermPair client:
 ```
 > termpair share --help
-usage: termpair share [-h] [--cmd CMD] [--port PORT] [--host HOST]
-                      [--no-browser-control] [--open-browser]
+usage: termpair share [-h] [--cmd CMD] [--port PORT] [--host HOST] [--read-only]
+                      [--open-browser]
 
-Share your terminal session with one or more browsers. A termpair server must
-be running before using this command.
+Share your terminal session with one or more browsers. A termpair server must be
+running before using this command.
 
 optional arguments:
   -h, --help            show this help message and exit
-  --cmd CMD             The command to run in this TermPair session. Defaults
-                        to the SHELL environment variable (default: /bin/bash)
-  --port PORT, -p PORT  port server is running on (default: None)
+  --cmd CMD             The command to run in this TermPair session. Defaults to
+                        the SHELL environment variable (default: /bin/bash)
+  --port PORT, -p PORT  port server is running on (default: 8000)
   --host HOST           host server is running on (default: http://localhost)
-  --no-browser-control, -n
-                        Do not allow browsers to control your terminal
-                        remotely (default: False)
+  --read-only, -r       Do not allow browsers to write to the terminal (default:
+                        False)
   --open-browser, -b    Open a browser tab to the terminal after you start
                         sharing (default: False)
 ```

--- a/termpair/frontend_src/src/BottomBar.tsx
+++ b/termpair/frontend_src/src/BottomBar.tsx
@@ -19,8 +19,8 @@ export function BottomBar(props: {
       after sharing has begun."
     >
       {props.terminalData?.allow_browser_control && connected
-        ? "can type"
-        : "cannot type"}
+        ? "read/write"
+        : "read only"}
     </div>
   ) : null;
 

--- a/termpair/main.py
+++ b/termpair/main.py
@@ -46,10 +46,10 @@ def get_parser():
         "--host", default="http://localhost", help="host server is running on"
     )
     share_parser.add_argument(
-        "--no-browser-control",
-        "-n",
+        "--read-only",
+        "-r",
         action="store_true",
-        help="Do not allow browsers to control your terminal remotely",
+        help="Do not allow browsers to write to the terminal",
     )
     share_parser.add_argument(
         "--open-browser",
@@ -106,7 +106,7 @@ def run_command(args):
         else:
             url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
         url = url if url.endswith("/") else f"{url}/"
-        allow_browser_control = not args.no_browser_control
+        allow_browser_control = not args.read_only
         try:
             asyncio.get_event_loop().run_until_complete(
                 share.broadcast_terminal(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `CHANGELOG.md`

## Summary of changes
* Rename `--no-browser-control` argument of `termpair share` to `--read-only`

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
make build_frontend
nox -s broadcast
nox -s broadcast -- --read-only
```
Confirm no error was thrown by python and the UI looked correct
