### PR TITLE
require subparser command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1.2
+* [bugfix] Require command in command line. `termpair` now results in an error instead of displaying no output and returning 0.
+
 ## 0.3.1.1
 * [feature] add small, dark grey outline around the terminal
 * [bugfix] center the terminal instead of left aligning it

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,13 +50,13 @@ def build_executable(session):
     session.run("pex", ".", "-c", "termpair", "-o", "build/termpair", external=True)
 
 
-@nox.session(python=python)
+@nox.session()
 def publish_docs(session):
     session.install(*doc_deps)
     session.run("mkdocs", "gh-deploy")
 
 
-@nox.session(python=python)
+@nox.session()
 def publish_static_webapp(session):
     build_frontend(session)
     session.run("git", "checkout", "gh-pages", external=True)
@@ -68,7 +68,7 @@ def publish_static_webapp(session):
     session.run("git", "push", "origin", "gh-pages", external=True)
 
 
-@nox.session(python=python)
+@nox.session()
 def publish(session):
     print("REMINDER: Has the changelog been updated?")
     session.run("rm", "-rf", "dist", "build", external=True)

--- a/termpair/constants.py
+++ b/termpair/constants.py
@@ -6,4 +6,4 @@ class TermPairError(Exception):
 
 
 # this must match constants.ts
-TERMPAIR_VERSION = "0.3.1.1"
+TERMPAIR_VERSION = "0.3.1.2"

--- a/termpair/frontend_src/src/constants.ts
+++ b/termpair/frontend_src/src/constants.ts
@@ -1,6 +1,6 @@
 import { Terminal as Xterm } from "xterm";
 // this must match constants.py
-export const TERMPAIR_VERSION = "0.3.1.1";
+export const TERMPAIR_VERSION = "0.3.1.2";
 
 export const defaultTermpairServer = new URL(
   `${window.location.protocol}//${window.location.hostname}:${window.location.port}${window.location.pathname}`

--- a/termpair/main.py
+++ b/termpair/main.py
@@ -21,7 +21,7 @@ def get_parser():
         description="View and control remote terminals from your browser",
     )
     p.add_argument("--version", action="store_true")
-    subparsers = p.add_subparsers(dest="command")
+    subparsers = p.add_subparsers(dest="command", required=True)
 
     share_parser = subparsers.add_parser(
         "share",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `CHANGELOG.md`

## Summary of changes
Require subcommand so the CLI is not confusing if `serve` or `share` is not entered. Instead of silently exiting successfully and not doing anything, an error is raised to tell the user they need to enter a subcommand.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

before
```
> nox -s build_executable-3.9
> ./build/termpair  # error is expected but nothing happens
```

after
```
> nox -s build_executable-3.9
> ./build/termpair  # error is expected
usage: termpair [-h] [--version] {share,serve} ...
termpair: error: the following arguments are required: command
```
