### PR TITLE
fix sharemyclaude url

### DIFF
--- a/termpair-rs/frontend/static/index.html
+++ b/termpair-rs/frontend/static/index.html
@@ -115,7 +115,7 @@
       <p class="learn-more">Learn more about the architecture and encryption on <a href="https://github.com/cs01/termpair">GitHub</a>.</p>
 
       <div data-section="callout" class="callout">
-        Sharing Claude Code? Try <a href="https://chadsmith.dev/sharemyclaude/">Share My Claude</a> &mdash; built on TermPair, with a public relay so you can share instantly.
+        Sharing Claude Code? Try <a href="https://sharemyclau.de">Share My Claude</a> &mdash; built on TermPair, with a public relay so you can share instantly.
       </div>
 
       <p id="disclaimer" class="disclaimer" style="display:none"></p>


### PR DESCRIPTION
## Summary
- Fix callout link from `chadsmith.dev/sharemyclaude/` to `sharemyclau.de`

## Test plan
- [ ] Verify link works on landing page